### PR TITLE
implementing TerraformOutput output for terraform output -json like s…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,15 +44,16 @@ Examples:
   $ terraform-docs md ./my-module ../config.tf
 
 Options:
-  -i, --inputs             Render only inputs
-  -o, --outputs            Render only outputs
-  -d, --detailed           Render detailed value for <list> and <map>
-  -c, --color              Force rendering of color even if the output is redirected or piped
-  -C, --no-color           Do not use color to render the result
-  -R, --no-required        Do not output "Required" column
-  -O, --out-values=<file>  File used to get output values (result of 'terraform output -json' or 'terraform plan -out file')
-  -v, --var-file=<file>... Files used to assign values to terraform variables (HCL format)
-  -h, --help               Show help information
+  -i,  --inputs             Render only inputs
+  -o,  --outputs            Render only outputs
+  -t,  --terraform-output	  Render outputs in terraform output format
+  -d,  --detailed           Render detailed value for <list> and <map>
+  -c,  --color              Force rendering of color even if the output is redirected or piped
+  -C,  --no-color           Do not use color to render the result
+  -R,  --no-required        Do not output "Required" column
+  -O,  --out-values=<file>  File used to get output values (result of 'terraform output -json' or 'terraform plan -out file')
+  -v,  --var-file=<file>... Files used to assign values to terraform variables (HCL format)
+  -h,  --help               Show help information
 ```
 
 ## Example

--- a/doc/doc.go
+++ b/doc/doc.go
@@ -42,16 +42,16 @@ type Value struct {
 
 // Output represents a terraform output.
 type Output struct {
-	Name        string `xml:",attr"`
-	Description string `json:",omitempty" yaml:",omitempty" xml:",comment"`
-	Result      `yaml:",inline,omitempty" hcl:",inline,omitempty"`
+	Name        string `json:"name,omitempty" xml:",attr"`
+	Description string `json:"description,omitempty" yaml:",omitempty" xml:",comment"`
+	Result      `json:"result,omitempty" yaml:",inline,omitempty" hcl:",inline,omitempty"`
 }
 
 // Result represents a terraform output value.
 type Result struct {
-	Sensitive bool        `json:",omitempty" yaml:",omitempty" xml:",attr,omitempty"`
-	Type      string      `json:",omitempty" yaml:",omitempty" xml:",attr,omitempty"`
-	Value     interface{} `json:",omitempty" yaml:",omitempty" xml:",omitempty"`
+	Sensitive bool        `json:"sensitive,omitempty" yaml:",omitempty" xml:",attr,omitempty"`
+	Type      string      `json:"type,omitempty" yaml:",omitempty" xml:",attr,omitempty"`
+	Value     interface{} `json:"value,omitempty" yaml:",omitempty" xml:",omitempty"`
 }
 
 func (o Output) String() string {
@@ -63,7 +63,7 @@ func (o Output) String() string {
 
 // Doc represents a terraform module doc.
 type Doc struct {
-	Comment string   `json:",omitempty" yaml:",omitempty" xml:",comment"`
+	Comment string   `json:"comment,omitempty" yaml:",omitempty" xml:",comment"`
 	Inputs  []Input  `json:"inputs,omitempty" yaml:",omitempty" xml:"Inputs>Input"`
 	Outputs []Output `json:"outputs,omitempty" yaml:",omitempty" xml:"Outputs>Output"`
 }

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ var version = "dev"
 
 const usage = `
 Usage:
-  terraform-docs [--inputs| --outputs] [--detailed] [--no-required] [--out-values=<file>] [--var-file=<file>...] [--color| --no-color] [json | yaml | hcl | md | markdown | xml] [<path>...]
+  terraform-docs [--inputs| --outputs] [--terraform-output] [--detailed] [--no-required] [--out-values=<file>] [--var-file=<file>...] [--color| --no-color] [json | yaml | hcl | md | markdown | xml] [<path>...]
   terraform-docs -h | --help
 
 Examples:
@@ -46,6 +46,7 @@ Examples:
 Options:
   -i, --inputs             Render only inputs
   -o, --outputs            Render only outputs
+  -t, --terraform-output   Render outputs in terraform output format ('terraform output -json')
   -d, --detailed           Render detailed value for <list> and <map>
   -c, --color              Force rendering of color even if the output is redirected or piped
   -C, --no-color           Do not use color to render the result
@@ -169,7 +170,11 @@ func main() {
 	case args["markdown"].(bool) || args["md"].(bool):
 		out, err = print.Markdown(document, renderMode, printRequired, args["--out-values"] != nil)
 	case args["json"].(bool):
-		out, err = print.JSON(document, renderMode)
+		if args["--terraform-output"].(bool) {
+			out, err = print.TerraformOutput(document, renderMode)
+		} else {
+			out, err = print.JSON(document, renderMode)
+		}
 	case args["yaml"].(bool):
 		out, err = print.YAML(document, renderMode)
 	case args["hcl"].(bool):

--- a/print/print.go
+++ b/print/print.go
@@ -149,6 +149,21 @@ func Markdown(d *doc.Doc, mode RenderMode, printRequired, printValues bool) (str
 	return buf.String(), nil
 }
 
+// TerraformOutput prints the given doc as 'terraform output -json'.
+func TerraformOutput(d *doc.Doc, mode RenderMode) (string, error) {
+	jsonOutput := make(map[string]doc.Result)
+	for i := range filter(*d, mode).Outputs {
+		o := &d.Outputs[i]
+		jsonOutput[o.Name] = o.Result
+	}
+	result, err := json.MarshalIndent(jsonOutput, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}
+
 // JSON prints the given doc as json.
 func JSON(d *doc.Doc, mode RenderMode) (string, error) {
 	result, err := json.MarshalIndent(filter(*d, mode), "", "  ")


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

If we change a Terraform project and the only difference with the previous run is output changes (add, remove or modify a value), this is not considered as a change by terraform plan.

We should modify the plan script to gather the output after the plan. The output is not directly available as of Terraform 0.11.X

The idea is to extract the plan from the plan file (-out) and compare it with either the state file or the output.

This is what this new feature is doing (export the output like terraform output -json) to allow future comparison.

### Checklist

Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### Code Style

- [x] My code follows the code style of this project.
