### PR TITLE
Allow not ouputting the `Sensitive` attribute and use literal var name

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ var version = "dev"
 
 const usage = `
 Usage:
-  terraform-docs [--inputs| --outputs] [--terraform-output] [--detailed] [--no-required] [--out-values=<file>] [--var-file=<file>...] [--color| --no-color] [json | yaml | hcl | md | markdown | xml] [<path>...]
+  terraform-docs [--inputs| --outputs] [--terraform-output] [--detailed] [--no-required] [--no-sensitive] [--out-values=<file>] [--var-file=<file>...] [--color| --no-color] [json | yaml | hcl | md | markdown | xml] [<path>...]
   terraform-docs -h | --help
 
 Examples:
@@ -51,6 +51,7 @@ Options:
   -c, --color              Force rendering of color even if the output is redirected or piped
   -C, --no-color           Do not use color to render the result
   -R, --no-required        Do not output "Required" column
+  -S, --no-sensitive       Do not output "Sensitive" column
   -O, --out-values=<file>  File used to get output values (result of 'terraform output -json' or 'terraform plan -out file')
   -v, --var-file=<file>... Files used to assign values to terraform variables (HCL format) 
   -h, --help               Show help information
@@ -168,13 +169,14 @@ func main() {
 	}
 
 	printRequired := !args["--no-required"].(bool)
+	printSensitive := !args["--no-sensitive"].(bool)
 	terraformOutput := args["--terraform-output"].(bool)
 
 	var out string
 
 	switch {
 	case args["markdown"].(bool) || args["md"].(bool):
-		out, err = print.Markdown(document, renderMode, printRequired, args["--out-values"] != nil)
+		out, err = print.Markdown(document, renderMode, printRequired, printSensitive, args["--out-values"] != nil)
 	case args["json"].(bool):
 		out, err = print.JSON(document, renderMode, terraformOutput)
 	case args["yaml"].(bool):

--- a/print/print.go
+++ b/print/print.go
@@ -80,7 +80,7 @@ func Pretty(d *doc.Doc, mode RenderMode) (string, error) {
 }
 
 // Markdown prints the given doc as markdown.
-func Markdown(d *doc.Doc, mode RenderMode, printRequired, printValues bool) (string, error) {
+func Markdown(d *doc.Doc, mode RenderMode, printRequired, printSensitive, printValues bool) (string, error) {
 	var buf bytes.Buffer
 
 	if len(d.Comment) > 0 {
@@ -129,9 +129,14 @@ func Markdown(d *doc.Doc, mode RenderMode, printRequired, printValues bool) (str
 		if len(d.Outputs) > 0 {
 			var ext, sep string
 			if printValues {
-				ext = " Value | Type | Sensitive |"
-				sep = "-------|------|-----------|"
+				ext = " Value | Type |"
+				sep = "-------|------|"
+				if printSensitive {
+					ext += " Sensitive |"
+					sep += "-----------|"
+				}
 			}
+
 			buf.WriteString("\n## Outputs\n\n")
 			buf.WriteString(fmt.Sprintf("| Name | Description |%s\n", ext))
 			buf.WriteString(fmt.Sprintf("|------|-------------|%s\n", sep))
@@ -140,9 +145,13 @@ func Markdown(d *doc.Doc, mode RenderMode, printRequired, printValues bool) (str
 		for _, v := range d.Outputs {
 			var val string
 			if printValues {
-				val = fmt.Sprintf(" `%v ` | %s | %s |", v, v.Result.Type, humanize(v.Result.Sensitive))
+				val = fmt.Sprintf(" `%v ` | %s |", v, v.Result.Type)
+				if printSensitive {
+					val += fmt.Sprintf(" %s |", humanize(v.Result.Sensitive))
+				}
 			}
-			buf.WriteString(fmt.Sprintf("| %s | %s |%s\n", v.Name, normalizeMarkdownDesc(v.Description), val))
+
+			buf.WriteString(fmt.Sprintf("| `%s` | %s |%s\n", v.Name, normalizeMarkdownDesc(v.Description), val))
 		}
 	}
 


### PR DESCRIPTION
In our case. The `Sensitive` attribute is always false since we don't output sensitive info. So we don't want it to show up in our markdown docs

Also add backticks to the variable names because markdown would interpret my_var_name as italics