### PR TITLE
[DT-4462] Handle cases where the value of an output isn't defined

### DIFF
--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -192,11 +192,15 @@ func loadOutputs(tfmodule *tfconfig.Module, options *Options) ([]*tfconf.Output,
 			ShowValue: options.OutputValues,
 		}
 		if options.OutputValues {
-			output.Sensitive = values[output.Name].Sensitive
-			if values[output.Name].Sensitive {
-				output.Value = types.ValueOf(`<sensitive>`)
+			if value, ok := values[output.Name]; ok {
+				output.Sensitive = value.Sensitive
+				if value.Sensitive {
+					output.Value = types.ValueOf(`<sensitive>`)
+				} else {
+					output.Value = types.ValueOf(value.Value)
+				}
 			} else {
-				output.Value = types.ValueOf(values[output.Name].Value)
+				return nil, fmt.Errorf("value from output %s is undefined (this can happen when you have an output that is evaluated to null by Terraform)", output.Name)
 			}
 		}
 		outputs = append(outputs, output)


### PR DESCRIPTION
Let's say you have 

```hcl
output "foo" {
  value = val.bar == "barfish" ? aws_pool.aws_barfish.name : null
}
```

In cases where the output is evaluated as null, the foo output will be missing from the result of the command `terraform output -json`. 

Since terraform-docs parses the terraform files to find all the outputs and then matchs those outputs with the result of the `terraform output -json` commad, you get a beautiful stacktrace on those cases. At least now you have a clear error message.
